### PR TITLE
fixing typos

### DIFF
--- a/_manual/code_style.md
+++ b/_manual/code_style.md
@@ -9,21 +9,20 @@ order: 20
 
 I am pretty certain that setting too narrow code style rules just leads to chaos... The reason being that if the rules are too strict, none will ever follow 100% of them, resulting in non respected code style chart. That's why there will be no more PSR-2 or 3.
 
-That being said, you will soon find here a complete list of our requirements. These are basic rules that you have to follow. We won't merge any commit not respecting these few  rules!
-
+That being said, you will soon find here a complete list of our requirements. These are basic rules that you have to follow. We won't merge any commit not respecting these few rules!
 
 # Flyspray code style
 
-### Identation
+### Indentation
 
-* You will use tabs to correctly ident your code. Spaces are only authorized to fine tune your identation in case of multiline if statements per exemple
-* Childs must be correctly ident to their respective parents, and that is for any language, php of course, but html, css, javascript of any other languages FS is or will use.
+* You will use tabs to correctly ident your code. Spaces are only authorized to fine tune your indentation in case of multiline if statements per example
+* Childs must be correctly indent to their respective parents, and that is for any language, PHP of course, but HTML, CSS, Javascript or any other programming language or format Flyspray uses.
 
-### variables
+### Variables
 
 * Use english only for variables
-* Name your variables correctly. Their name must be in direct relation to their use
-* We follow the camelCase convention
+* Name your variables correctly. Their name must be in direct relation to their use.
+* We follow the camelCase convention for Javascript and PHP
 ``` php
 <?php
 


### PR DESCRIPTION
personal comment: indentation of CSS should be allowed with less indentation. 
For example

``` css
body{background-color:#fff;}
p{
color:#000;
margin:5px;
}
```

should be ok. 
CSS is transfered to the client browser and should be small as possible. And it is readable with this less indentions too.
