### PR TITLE
Fix external links in blog posts

### DIFF
--- a/_posts/News/2015-10-08-security-release-1.0-beta.md
+++ b/_posts/News/2015-10-08-security-release-1.0-beta.md
@@ -6,4 +6,4 @@ date: 2015-10-08 00:00:00
 summary: Developer release addressing security issues
 ---
 
-See https://github.com/Flyspray/flyspray/releases
+See [https://github.com/Flyspray/flyspray/releases](https://github.com/Flyspray/flyspray/releases)

--- a/_posts/News/2015-10-12-release-1.0-beta.2.md
+++ b/_posts/News/2015-10-12-release-1.0-beta.2.md
@@ -6,4 +6,4 @@ date: 2015-10-12 00:00:00
 summary: Release of Flyspray 1.0 Beta2
 ---
 
-See https://github.com/Flyspray/flyspray/releases
+See [https://github.com/Flyspray/flyspray/releases](https://github.com/Flyspray/flyspray/releases)

--- a/_posts/News/2016-03-23-release-1.0-rc.md
+++ b/_posts/News/2016-03-23-release-1.0-rc.md
@@ -6,4 +6,4 @@ date: 2016-03-23 14:00:00
 summary: Release of Flyspray 1.0 RC
 ---
 
-See https://github.com/Flyspray/flyspray/releases
+See [https://github.com/Flyspray/flyspray/releases](https://github.com/Flyspray/flyspray/releases)

--- a/_posts/News/2016-04-10-release-1.0-rc1.md
+++ b/_posts/News/2016-04-10-release-1.0-rc1.md
@@ -6,6 +6,6 @@ date: 2016-04-10 23:00:00
 summary: Release of Flyspray 1.0 RC1
 ---
 
-Source: https://github.com/Flyspray/flyspray/releases
+Source: [https://github.com/Flyspray/flyspray/releases](https://github.com/Flyspray/flyspray/releases)
 
-Downloads including third libraries: http://www.flyspray.org/docs/download
+Downloads including third libraries: [https://www.flyspray.org/docs/download](https://www.flyspray.org/docs/download)

--- a/_posts/News/2016-11-18-release-1.0-rc4.md
+++ b/_posts/News/2016-11-18-release-1.0-rc4.md
@@ -8,4 +8,4 @@ summary: Security release of Flyspray 1.0 rc4
 
 Security update
 
-https://github.com/Flyspray/flyspray/releases
+[https://github.com/Flyspray/flyspray/releases](https://github.com/Flyspray/flyspray/releases)

--- a/_posts/News/2017-10-05-release-1.0-rc6.md
+++ b/_posts/News/2017-10-05-release-1.0-rc6.md
@@ -8,4 +8,4 @@ summary: Security release of Flyspray 1.0 rc6
 
 Security update
 
-https://github.com/Flyspray/flyspray/releases
+[https://github.com/Flyspray/flyspray/releases](https://github.com/Flyspray/flyspray/releases)

--- a/_posts/News/2018-07-16-release-1.0-rc7.md
+++ b/_posts/News/2018-07-16-release-1.0-rc7.md
@@ -17,4 +17,4 @@ Main Changes:
 
 and small bugfixes.
 
-https://github.com/Flyspray/flyspray/releases
+[https://github.com/Flyspray/flyspray/releases](https://github.com/Flyspray/flyspray/releases)


### PR DESCRIPTION
It seems jekyll doesn't turn http: or https: urls into clickable links (anymore?). - while editing the markdown .md files here on github.com with previews look fine. :-(

So as workaround use the explicit syntax `[url](linktext)` for defining external links for www.flyspray.org jekyll/github pages.