### PR TITLE
single page manual

### DIFF
--- a/_manual/generate-single-page-manual.sh
+++ b/_manual/generate-single-page-manual.sh
@@ -1,0 +1,32 @@
+cat                              \
+    install.md                   \
+    project-management.md        \
+    project-lists.md             \
+    themes.md                    \
+    user_management.md           \
+    understanding_permissions.md \
+    global_groups.md             \
+    project_groups.md            \
+    group_permissions.md         \
+    searching_tasks.md           \
+    viewing_task_details.md      \
+    editing_task_details.md      \
+    dependencies.md              \
+    private_tasks.md             \
+    comments.md                  \
+    attachments.md               \
+    related_tasks.md             \
+    notifications.md             \
+    categories_and_tags.md       \
+    reminders.md                 \
+    closing_tasks.md             \
+    history.md                   \
+    global_options.md            \
+    global_lists.md              \
+    reports.md                   \
+    devel_version.md             \
+    code_style.md                \
+    pull_request.md              \
+    writing_documentation.md     \
+    translate.md                 \
+    > single-page-manual.md      \


### PR DESCRIPTION
# Expected result:
The ability to search the manual/documentation for keywords.

# Actual result:
Cannot search the manual/documentation for keywords.

Example:

I see in my bug tracker that I have voted for a task.  I have no idea how this was done and would like to rescind the vote.  The first step in finding the solution is to RTFM.  However, searching for the string "vote" requires searching 30 separate pages.

# Analysis of problem:
The manual is split into separate documents.  Each of the documents can be searched, but the manual as a whole is not searchable.  

# Suggested solutions
There are several ways this problem could be solved, such as

1. Include search functionality on flyspray.org
2. Provide a single page version of the manual

# Pull request
I believe the simplest solution is to combine all the manual `.md` files into a single `.md` file.  This offloads the searching task onto a third-party application (web-browser or text editor).  I have created a simple shell script which concatenates all the manuals into a single document, in the order they are currently listed on the [manual page](https://www.flyspray.org/manual/).

Implementing this solution requires several other tasks, primarily how to make the single page manual discoverable.  I imagine the main index will need to be updated with a link, as well as each individual manual page.  

* Will the concatenated files render properly?
* What other pages will need to be updated for discoverability (i.e. links)

What are your thoughts on this?  